### PR TITLE
Set page fill parameter to none

### DIFF
--- a/org-typst-preview.el
+++ b/org-typst-preview.el
@@ -139,7 +139,7 @@ Currently passes weight and size."
 (defun org-typst-preview--generate-typst-file (file-path typst-code &optional common-configuration)
   "Generate typst file at FILE-PATH with TYPST-CODE and COMMON-CONFIGURATION."
   (with-temp-file file-path
-    (insert "#set page(width: auto, height: auto, margin: (x: 0pt, y: 0pt))\n") ;; , margin: (x: 20pt, y: 20pt)
+    (insert "#set page(fill: none, width: auto, height: auto, margin: (x: 0pt, y: 0pt))\n") ;; , margin: (x: 20pt, y: 20pt)
     (insert (format "#set text(fill: %s, %s)\n"
                     (org-typst-preview--typst-foreground-color)
                     (org-typst-preview--typst-font-settings)))


### PR DESCRIPTION
Typst defaults to `white` background for PNG and SVG outputs.

Sets page `fill` parameter to `none` to create overlays with transparent background.
