### PR TITLE
Adjust some default behaviors of the package

### DIFF
--- a/org-typst-preview.el
+++ b/org-typst-preview.el
@@ -218,6 +218,7 @@ BEG and END are buffer positions."
   (unless (org-typst-preview--remove-overlays-in-range beg end)
     (org-typst-preview-format beg end)))
 
+;;;###autoload
 (defun org-typst-preview ()
   "Toggle preview of the Typst fragment at point.
 
@@ -234,11 +235,13 @@ When there's active region render or remove it instead."
           (org-typst-preview--select-code-block))
         (org-typst-preview--region (region-beginning) (region-end))))))
 
+;;;###autoload
 (defun org-typst-preview-clear-buffer ()
   "Remove all Typst code blocks rendered images in buffer."
   (interactive)
   (org-typst-preview--remove-overlays-in-range (point-min) (point-max)))
 
+;;;###autoload
 (defun org-typst-preview-render-buffer ()
   "Render all (unrendered) Typst code blocks in buffer."
   (interactive)
@@ -279,11 +282,6 @@ Run rerender on every theme change."
 ;; (advice-add 'load-theme :after #'org-typst-preview--rerender-all-org-buffers)
 ;; (advice-add 'enable-theme :after #'org-typst-preview--rerender-all-org-buffers)
 ;; (advice-add 'disable-theme :after #'org-typst-preview--rerender-all-org-buffers)
-
-;; Bindings
-(org-defkey org-mode-map (kbd "C-c C-x C-t") #'org-typst-preview)
-(org-defkey org-mode-map (kbd "C-c C-x t t") #'org-typst-preview-render-buffer)
-(org-defkey org-mode-map (kbd "C-c C-x t c") #'org-typst-preview-clear-buffer)
 
 (provide 'org-typst-preview)
 ;;; org-typst-preview.el ends here


### PR DESCRIPTION
1. Add autoload to three functions: `org-typst-preview`, `org-typst-preview-clear-buffer` and `org-typst-preview-render-buffer`.
2. Remove default keybindings since it conflicts with existing keybindings for `org-toggle-time-stamp-overlays`. 
3. `org-typst-preview` now toggle the overlay of the Typst code fragment closest to point. Now, it is no longer required to place the cursor on a Typst code fragment. Also gracely hanlde the special case when there is no Typst fragment. Remove the feature that `org-typst-preview` may work on a selected region, since the selected region may contain incomplete Typst fragment.